### PR TITLE
fixed bug in gamma pdf

### DIFF
--- a/+logdist/fnGamma.m
+++ b/+logdist/fnGamma.m
@@ -22,7 +22,7 @@ end
 
 switch lower(varargin{1})
     case {'proper', 'pdf'}
-        y(ix) = x.^(a-1).*exp(-x/b) / (b^a*gamma(a));
+        y(ix) = gampdf(x,a,b);
     case 'info'
         y(ix) = (a - 1)/x.^2;
         y(~ix) = NaN;


### PR DESCRIPTION
the following example generates empty figure:
```
E.x = {2, 0, Inf, logdist.gamma(2,.1)};
plotpp(E);
```
please replace line 25 of logdist.fnGamma:
from `y(ix) = x.^(a-1).*exp(-x/b) / (b^a*gamma(a));`
to `y(ix) = gampdf(x,a,b);`