### PR TITLE
user defined .mean and .mse in initUnit

### DIFF
--- a/+shared/@Kalman/initialize.m
+++ b/+shared/@Kalman/initialize.m
@@ -77,12 +77,16 @@ return
             a0 = [a1; a2];
         end
 
-        if numUnitRoots>0 && isnumeric(initUnit)
+        if numUnitRoots>0 && (isnumeric(initUnit) || iscell(initUnit))
             %
             % User supplied data to initialize mean for unit root processes
             % Convert XiB to Alpha
             %
-            xb00 = initUnit;
+            if iscell(initUnit)
+                xb00 = initUnit{1};
+            else
+                xb00 = initUnit;
+            end
             inxZero = isnan(xb00) & ~inxInit;
             xb00(inxZero) = 0;
             if needsTransform
@@ -168,6 +172,9 @@ return
                 end
                 PaInf = zeros(numXiB);
                 PaInf(~inxStable, ~inxStable) = eye(numUnitRoots) * scale;
+            elseif iscell(initUnit) && numel(initUnit)>=2
+                
+                PaReg(~inxStable, ~inxStable)= initUnit{2}(~inxStable, ~inxStable);
             end
         end
     end%

--- a/+shared/@Kalman/kalmanFilter.m
+++ b/+shared/@Kalman/kalmanFilter.m
@@ -258,6 +258,8 @@ for run = 1 : numRuns
     end
     if isnumeric(opt.InitUnitRoot)
         initUnit__ = opt.InitUnitRoot(:, :, min(end, run));
+    elseif iscell(opt.InitUnitRoot)
+        initUnit__ = cellfun(@(x) x(:, :, min(end, run)), opt.InitUnitRoot, 'UniformOutput', false);
     else
         initUnit__ = opt.InitUnitRoot;
     end

--- a/+shared/@Kalman/prepareKalmanOptions.m
+++ b/+shared/@Kalman/prepareKalmanOptions.m
@@ -202,11 +202,11 @@ end
 % Initial condition for unit root components
 %
 if isstruct(opt.InitUnitRoot)
-    [xbInitMean, listMissingMeanInit] = ...
+    [xbInitMean, listMissingMeanInit, xbInitMse, listMissingMSEInit] = ...
         datarequest('xbInit', this, opt.InitUnitRoot, range);
     listMissingMSEInit = cell.empty(1, 0);
     hereCheckNaNInit( );
-    opt.InitUnitRoot = xbInitMean;
+    opt.InitUnitRoot = {xbInitMean, xbInitMse};
 end
 
 % Last backward smoothing period. The option  lastsmooth will not be


### PR DESCRIPTION
A few suggested changes so that both .mean and .mse can be set when user defined initial conditions are supplied for unit root variables when calling filter.m